### PR TITLE
Iframe double buffering

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,14 +309,14 @@
     var previousHtml = "",
         currentHtml = "",
         BACK = 3, // CodeMirror's z-index is 2, this will be above that.
-        FRONT = 4,
+        FRONT = 4, // This is for the "front buffer", visible to the user.
         buffers = [BACK, FRONT],
         root,
-        iframe,
-        needsSwap = false;
+        needsSwap = false,
+        framesPerSecond = 10; // Seems to be the fastest rate without flicker.
 
     setInterval(function (){
-      if(iframe){
+      if(root){
         if(needsSwap){
           buffers = buffers.reverse();
           root.selectAll(".runner").data(buffers)
@@ -325,28 +325,26 @@
         }
         if(currentHtml !== previousHtml){
           previousHtml = currentHtml;
-          iframe
+          root.selectAll(".runner")
             .filter(function (z){ return z === BACK; })
             .attr("srcdoc", currentHtml);
           needsSwap = true;
         }
       }
-    }, 100);
+    }, 1000 / framesPerSecond);
 
     return function (selection){
       selection.each(function (state){
-
         root = d3.select(this);
-        iframe = root.selectAll(".runner").data(buffers);
-        iframe = iframe.merge(iframe.enter().append("iframe")
-          .attr("class", "shadow runner")
-          .attr("width", "960") // 960 X 500 is standard for bl.ocks.org.
-          .attr("height", "500")
-          .attr("marginwidth", "0") // Have no margin to match with bl.ocks.org.
-          .attr("marginheight", "0")
-          .attr("frameborder", "0px")
-          .attr("scrolling", "no"));
-
+        root.selectAll(".runner").data(buffers)
+          .enter().append("iframe")
+            .attr("class", "shadow runner")
+            .attr("width", "960") // 960 X 500 is standard for bl.ocks.org.
+            .attr("height", "500")
+            .attr("marginwidth", "0") // Have no margin to match with bl.ocks.org.
+            .attr("marginheight", "0")
+            .attr("frameborder", "0px")
+            .attr("scrolling", "no");
         currentHtml = state.html;
       });
     };

--- a/index.html
+++ b/index.html
@@ -66,7 +66,6 @@
         top: 0px;
         right: 0px;
         background-color: white;
-        z-index: 3; /* CodeMirror's z-index is 2. */
       }
 
       .overlay {
@@ -307,10 +306,38 @@
 
   // User interface component for the running example (top right).
   function Runner(){
-    var previousHtml = "";
+    var previousHtml = "",
+        currentHtml = "",
+        BACK = 3, // CodeMirror's z-index is 2, this will be above that.
+        FRONT = 4,
+        buffers = [BACK, FRONT],
+        root,
+        iframe,
+        needsSwap = false;
+
+    setInterval(function (){
+      if(iframe){
+        if(needsSwap){
+          buffers = buffers.reverse();
+          root.selectAll(".runner").data(buffers)
+            .style("z-index", function (z) { return z; });
+          needsSwap = false;
+        }
+        if(currentHtml !== previousHtml){
+          previousHtml = currentHtml;
+          iframe
+            .filter(function (z){ return z === BACK; })
+            .attr("srcdoc", currentHtml);
+          needsSwap = true;
+        }
+      }
+    }, 100);
+
     return function (selection){
       selection.each(function (state){
-        var iframe = d3.select(this).selectAll(".runner").data([1]);
+
+        root = d3.select(this);
+        iframe = root.selectAll(".runner").data(buffers);
         iframe = iframe.merge(iframe.enter().append("iframe")
           .attr("class", "shadow runner")
           .attr("width", "960") // 960 X 500 is standard for bl.ocks.org.
@@ -320,10 +347,7 @@
           .attr("frameborder", "0px")
           .attr("scrolling", "no"));
 
-        if(state.html !== previousHtml){
-          iframe.attr("srcdoc", state.html);
-          previousHtml = state.html;
-        }
+        currentHtml = state.html;
       });
     };
   }


### PR DESCRIPTION
This adds double buffering to the Runner component, to eliminate the flickering (flashes of white) that occur when the iframe source gets re-evaluated.

This technique is similar to [double buffering in computer graphics](https://en.wikipedia.org/wiki/Multiple_buffering#Double_buffering_in_computer_graphics). A fixed framerate is set. Each frame, if the source code changed, the back buffer (hidden iframe) is re-evaluated by setting the `srcdoc` attribute. At the next frame, the back buffer and font buffer are swapped, so the visible content gets updated. By the time the next frame rolls around, hopefully the back buffer has finished evaluating its `srcdoc` and is ready for viewing. This is how flickering is eliminated.

Now when you use Inlet to update a number or color, the updates are smooth, with no flashes of white in between updates.